### PR TITLE
Adding extra properties to the fetch task operation.

### DIFF
--- a/src/Camunda.Worker/Client/FetchAndLockRequest.cs
+++ b/src/Camunda.Worker/Client/FetchAndLockRequest.cs
@@ -59,6 +59,12 @@ namespace Camunda.Worker.Client
 
             public string? BusinessKey { get; set; }
 
+            /// <summary>Determines whether serializable variable values (typically variables that store custom Java objects) should be deserialized on server side (default false).</summary>
+            public bool DeserializeValues { get; set; }
+
+            /// <summary>Determines whether custom extension properties defined in the BPMN activity of the external task (e.g. via the Extensions tab in the Camunda modeler) should be included in the response. Default: false.</summary>
+            public bool IncludeExtensionProperties { get; set; }
+
             public string? ProcessDefinitionId { get; set; }
 
             public IReadOnlyCollection<string>? ProcessDefinitionIdIn { get; set; }

--- a/src/Camunda.Worker/Execution/HandlerMetadata.cs
+++ b/src/Camunda.Worker/Execution/HandlerMetadata.cs
@@ -16,6 +16,12 @@ namespace Camunda.Worker.Execution
 
         public bool LocalVariables { get; set; }
 
+        /// <summary>Determines whether serializable variable values (typically variables that store custom Java objects) should be deserialized on server side (default false).</summary>
+        public bool DeserializeValues { get; set; }
+
+        /// <summary>Determines whether custom extension properties defined in the BPMN activity of the external task (e.g. via the Extensions tab in the Camunda modeler) should be included in the response. Default: false.</summary>
+        public bool IncludeExtensionProperties { get; set; }
+        
         public IReadOnlyList<string>? Variables { get; set; }
 
         public IReadOnlyList<string>? ProcessDefinitionIds { get; set; }

--- a/src/Camunda.Worker/Execution/StaticTopicsProvider.cs
+++ b/src/Camunda.Worker/Execution/StaticTopicsProvider.cs
@@ -26,7 +26,9 @@ namespace Camunda.Worker.Execution
                 Variables = metadata.Variables,
                 ProcessDefinitionIdIn = metadata.ProcessDefinitionIds,
                 ProcessDefinitionKeyIn = metadata.ProcessDefinitionKeys,
-                TenantIdIn = metadata.TenantIds
+                TenantIdIn = metadata.TenantIds,
+                DeserializeValues = metadata.DeserializeValues,
+                IncludeExtensionProperties = metadata.IncludeExtensionProperties,
             };
 
         public IReadOnlyCollection<FetchAndLockRequest.Topic> GetTopics()


### PR DESCRIPTION
**DeserializeValues**
Determines whether serializable variable values (typically variables that store custom Java objects) should be deserialized on server side (default false).

If set to true, a serializable variable will be deserialized on server side and transformed to JSON using Jackson's POJO/bean property introspection feature. Note that this requires the Java classes of the variable value to be on the REST API's classpath.

If set to false, a serializable variable will be returned in its serialized format. For example, a variable that is serialized as XML will be returned as a JSON string containing XML.

**IncludeExtensionProperties**
 Determines whether custom extension properties defined in the BPMN activity of the external task (e.g. via the Extensions tab in the Camunda modeler) should be included in the response. Default: false

Based on:
https://docs.camunda.org/manual/latest/reference/rest/external-task/fetch/#request-body

This change is to help retrieve variables that I can read from .net (JSON) as opposed to base64 serialized `java.util.TreeMap`s:

From:
![image](https://user-images.githubusercontent.com/1676879/127053873-afbfee8b-8a75-42b2-9a9c-1bfbd4e9868f.png)
![image](https://user-images.githubusercontent.com/1676879/127054259-fc752196-847a-42da-a43f-b69c45fed8e0.png)
To:
![image](https://user-images.githubusercontent.com/1676879/127054139-40b748dc-2780-4f2f-8258-ccdaf107eb7e.png)





