### PR TITLE
Adding ProcessVariables property in the FetchAndLock request

### DIFF
--- a/src/Camunda.Worker/Client/FetchAndLockRequest.cs
+++ b/src/Camunda.Worker/Client/FetchAndLockRequest.cs
@@ -74,7 +74,7 @@ namespace Camunda.Worker.Client
             public IReadOnlyCollection<string>? ProcessDefinitionKeyIn { get; set; }
 
             /// <summary>A dictionary used for filtering tasks based on process instance variable values. The property Key of the dictionary represents a process variable name, while the property value represents the process variable value to filter tasks by.</summary>
-            public IReadOnlyCollection<KeyValuePair<string, string>>? ProcessVariables { get; set; }
+            public IReadOnlyDictionary<string, string>? ProcessVariables { get; set; }
 
             public bool? WithoutTenantId { get; set; }
 

--- a/src/Camunda.Worker/Client/FetchAndLockRequest.cs
+++ b/src/Camunda.Worker/Client/FetchAndLockRequest.cs
@@ -73,6 +73,9 @@ namespace Camunda.Worker.Client
 
             public IReadOnlyCollection<string>? ProcessDefinitionKeyIn { get; set; }
 
+            /// <summary>A dictionary used for filtering tasks based on process instance variable values. The property Key of the dictionary represents a process variable name, while the property value represents the process variable value to filter tasks by.</summary>
+            public IReadOnlyCollection<KeyValuePair<string, string>>? ProcessVariables { get; set; }
+
             public bool? WithoutTenantId { get; set; }
 
             public IReadOnlyCollection<string>? TenantIdIn { get; set; }

--- a/src/Camunda.Worker/Execution/HandlerMetadata.cs
+++ b/src/Camunda.Worker/Execution/HandlerMetadata.cs
@@ -28,6 +28,9 @@ namespace Camunda.Worker.Execution
 
         public IReadOnlyList<string>? ProcessDefinitionKeys { get; set; }
 
+        /// <summary>A dictionary used for filtering tasks based on process instance variable values. The property Key of the dictionary represents a process variable name, while the property value represents the process variable value to filter tasks by.</summary>
+        public IReadOnlyDictionary<string, string>? ProcessVariables { get; set; }
+
         public IReadOnlyList<string>? TenantIds { get; set; }
     }
 }

--- a/src/Camunda.Worker/Execution/StaticTopicsProvider.cs
+++ b/src/Camunda.Worker/Execution/StaticTopicsProvider.cs
@@ -26,6 +26,7 @@ namespace Camunda.Worker.Execution
                 Variables = metadata.Variables,
                 ProcessDefinitionIdIn = metadata.ProcessDefinitionIds,
                 ProcessDefinitionKeyIn = metadata.ProcessDefinitionKeys,
+                ProcessVariables = metadata.ProcessVariables,
                 TenantIdIn = metadata.TenantIds,
                 DeserializeValues = metadata.DeserializeValues,
                 IncludeExtensionProperties = metadata.IncludeExtensionProperties,


### PR DESCRIPTION
Used to filter the external tasks (during `FetchAndLock`) using the variables contained within the workflow instance.
This property is available since Camunda Engine version 7.9

From API docs:
https://docs.camunda.org/manual/7.9/reference/rest/external-task/fetch/#request-body

<html>
<body>
<!--StartFragment-->

processVariables | A JSON object used for filtering tasks based on process instance variable values. A property name of the object represents a process variable name, while the property value represents the process variable value to filter tasks by.
-- | --


<!--EndFragment-->
</body>
</html>