### PR TITLE
Next version of the library

### DIFF
--- a/src/Camunda.Worker/CamundaWorkerBuilder.cs
+++ b/src/Camunda.Worker/CamundaWorkerBuilder.cs
@@ -54,9 +54,8 @@ public class CamundaWorkerBuilder : ICamundaWorkerBuilder
         Guard.NotNull(handler, nameof(handler));
         Guard.NotNull(handlerMetadata, nameof(handlerMetadata));
 
-        var descriptor = new HandlerDescriptor(handler, handlerMetadata, WorkerId);
-
-        Services.AddSingleton(descriptor);
+        var endpoint = new HandlerEndpoint(handler, handlerMetadata, WorkerId);
+        Services.AddSingleton(endpoint);
         return this;
     }
 

--- a/src/Camunda.Worker/Execution/FetchAndLockOptions.cs
+++ b/src/Camunda.Worker/Execution/FetchAndLockOptions.cs
@@ -2,15 +2,8 @@ namespace Camunda.Worker.Execution;
 
 public class FetchAndLockOptions
 {
-    private string _workerId = string.Empty;
     private int _maxTasks = 1;
     private int _asyncResponseTimeout = 10_000;
-
-    public string WorkerId
-    {
-        get => _workerId;
-        internal set => _workerId = Guard.NotEmptyAndNotNull(value, nameof(WorkerId));
-    }
 
     public int MaxTasks
     {

--- a/src/Camunda.Worker/Execution/HandlerDescriptor.cs
+++ b/src/Camunda.Worker/Execution/HandlerDescriptor.cs
@@ -2,13 +2,16 @@ namespace Camunda.Worker.Execution;
 
 public sealed class HandlerDescriptor
 {
-    public HandlerDescriptor(ExternalTaskDelegate handlerDelegate, HandlerMetadata metadata)
+    internal HandlerDescriptor(ExternalTaskDelegate handlerDelegate, HandlerMetadata metadata, WorkerIdString workerId)
     {
         HandlerDelegate = Guard.NotNull(handlerDelegate, nameof(handlerDelegate));
         Metadata = Guard.NotNull(metadata, nameof(metadata));
+        WorkerId = Guard.NotNull(workerId, nameof(workerId));
     }
 
     public ExternalTaskDelegate HandlerDelegate { get; }
 
     public HandlerMetadata Metadata { get; }
+
+    public WorkerIdString WorkerId { get; }
 }

--- a/src/Camunda.Worker/Execution/HandlerEndpoint.cs
+++ b/src/Camunda.Worker/Execution/HandlerEndpoint.cs
@@ -1,8 +1,8 @@
 namespace Camunda.Worker.Execution;
 
-public sealed class HandlerDescriptor
+public sealed class HandlerEndpoint
 {
-    internal HandlerDescriptor(ExternalTaskDelegate handlerDelegate, HandlerMetadata metadata, WorkerIdString workerId)
+    internal HandlerEndpoint(ExternalTaskDelegate handlerDelegate, HandlerMetadata metadata, WorkerIdString workerId)
     {
         HandlerDelegate = Guard.NotNull(handlerDelegate, nameof(handlerDelegate));
         Metadata = Guard.NotNull(metadata, nameof(metadata));

--- a/src/Camunda.Worker/Execution/LegacyFetchAndLockRequestProvider.cs
+++ b/src/Camunda.Worker/Execution/LegacyFetchAndLockRequestProvider.cs
@@ -5,14 +5,17 @@ namespace Camunda.Worker.Execution;
 
 internal class LegacyFetchAndLockRequestProvider : IFetchAndLockRequestProvider
 {
+    private readonly WorkerIdString _workerId;
     private readonly ITopicsProvider _topicsProvider;
     private readonly FetchAndLockOptions _options;
 
     internal LegacyFetchAndLockRequestProvider(
+        WorkerIdString workerId,
         ITopicsProvider topicsProvider,
         IOptions<FetchAndLockOptions> options
     )
     {
+        _workerId = workerId;
         _topicsProvider = topicsProvider;
         _options = options.Value;
     }
@@ -21,7 +24,7 @@ internal class LegacyFetchAndLockRequestProvider : IFetchAndLockRequestProvider
     {
         var topics = _topicsProvider.GetTopics();
 
-        var fetchAndLockRequest = new FetchAndLockRequest(_options.WorkerId, _options.MaxTasks)
+        var fetchAndLockRequest = new FetchAndLockRequest(_workerId.Value, _options.MaxTasks)
         {
             UsePriority = _options.UsePriority,
             AsyncResponseTimeout = _options.AsyncResponseTimeout,

--- a/src/Camunda.Worker/Execution/StaticTopicsProvider.cs
+++ b/src/Camunda.Worker/Execution/StaticTopicsProvider.cs
@@ -8,15 +8,15 @@ public sealed class StaticTopicsProvider : ITopicsProvider
 {
     private readonly IReadOnlyList<FetchAndLockRequest.Topic> _topics;
 
-    public StaticTopicsProvider(IEnumerable<HandlerDescriptor> handlerDescriptors)
+    public StaticTopicsProvider(IEnumerable<HandlerEndpoint> endpoints)
     {
-        _topics = handlerDescriptors.SelectMany(ConvertDescriptorToTopic).ToList();
+        _topics = endpoints.SelectMany(ConvertEndpointToTopic).ToList();
     }
 
-    private static IEnumerable<FetchAndLockRequest.Topic> ConvertDescriptorToTopic(HandlerDescriptor descriptor)
+    private static IEnumerable<FetchAndLockRequest.Topic> ConvertEndpointToTopic(HandlerEndpoint endpoint)
     {
-        return descriptor.Metadata.TopicNames
-            .Select(topicName => MakeTopicRequest(descriptor.Metadata, topicName));
+        return endpoint.Metadata.TopicNames
+            .Select(topicName => MakeTopicRequest(endpoint.Metadata, topicName));
     }
 
     private static FetchAndLockRequest.Topic MakeTopicRequest(HandlerMetadata metadata, string topicName) =>

--- a/src/Camunda.Worker/Execution/TopicBasedEndpointProvider.cs
+++ b/src/Camunda.Worker/Execution/TopicBasedEndpointProvider.cs
@@ -8,11 +8,11 @@ public class TopicBasedEndpointProvider : IEndpointProvider
 {
     private readonly IReadOnlyDictionary<string, ExternalTaskDelegate> _handlerDelegates;
 
-    public TopicBasedEndpointProvider(IEnumerable<HandlerDescriptor> descriptors)
+    public TopicBasedEndpointProvider(IEnumerable<HandlerEndpoint> endpoints)
     {
-        _handlerDelegates = descriptors
-            .SelectMany(descriptor => descriptor.Metadata.TopicNames
-                .Select(topicName => (topicName, handlerDelegate: descriptor.HandlerDelegate))
+        _handlerDelegates = endpoints
+            .SelectMany(endpoint => endpoint.Metadata.TopicNames
+                .Select(topicName => (topicName, handlerDelegate: endpoint.HandlerDelegate))
             )
             .ToDictionary(pair => pair.topicName, pair => pair.handlerDelegate);
     }

--- a/src/Camunda.Worker/ICamundaWorkerBuilder.cs
+++ b/src/Camunda.Worker/ICamundaWorkerBuilder.cs
@@ -8,7 +8,7 @@ public interface ICamundaWorkerBuilder
 {
     IServiceCollection Services { get; }
 
-    string WorkerId { get; }
+    WorkerIdString WorkerId { get; }
 
     ICamundaWorkerBuilder AddEndpointProvider<TProvider>() where TProvider : class, IEndpointProvider;
 

--- a/src/Camunda.Worker/IPipelineBuilder.cs
+++ b/src/Camunda.Worker/IPipelineBuilder.cs
@@ -4,9 +4,9 @@ namespace Camunda.Worker;
 
 public interface IPipelineBuilder
 {
-    string WorkerId { get; }
-
     IServiceProvider ApplicationServices { get; }
+
+    WorkerIdString WorkerId { get; }
 
     IPipelineBuilder Use(Func<ExternalTaskDelegate, ExternalTaskDelegate> middleware);
 

--- a/src/Camunda.Worker/PipelineBuilder.cs
+++ b/src/Camunda.Worker/PipelineBuilder.cs
@@ -11,15 +11,15 @@ public class PipelineBuilder : IPipelineBuilder
 {
     private readonly List<Func<ExternalTaskDelegate, ExternalTaskDelegate>> _middlewareList = new();
 
-    public PipelineBuilder(string workerId, IServiceProvider serviceProvider)
+    public PipelineBuilder(IServiceProvider serviceProvider, WorkerIdString workerId)
     {
-        WorkerId = workerId;
         ApplicationServices = serviceProvider;
+        WorkerId = workerId;
     }
 
-    public string WorkerId { get; }
-
     public IServiceProvider ApplicationServices { get; }
+
+    public WorkerIdString WorkerId { get; }
 
     public IPipelineBuilder Use(Func<ExternalTaskDelegate, ExternalTaskDelegate> middleware)
     {

--- a/src/Camunda.Worker/ServiceCollectionExtensions.cs
+++ b/src/Camunda.Worker/ServiceCollectionExtensions.cs
@@ -16,7 +16,7 @@ public static class CamundaWorkerServiceCollectionExtensions
         var workerIdString = new WorkerIdString(workerId);
         Guard.GreaterThanOrEqual(numberOfWorkers, Constants.MinimumParallelExecutors, nameof(numberOfWorkers));
 
-        services.AddOptions<FetchAndLockOptions>().Configure(options => { options.WorkerId = workerIdString.Value; });
+        services.AddOptions<FetchAndLockOptions>();
         services.AddOptions<WorkerEvents>();
         services.TryAddTransient<ITopicsProvider, StaticTopicsProvider>();
         services.TryAddTransient<ICamundaWorker, DefaultCamundaWorker>();

--- a/src/Camunda.Worker/WorkerIdString.cs
+++ b/src/Camunda.Worker/WorkerIdString.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Camunda.Worker;
+
+/// <summary>
+/// The type which represent a strongly typed valid worker's id
+/// </summary>
+public sealed class WorkerIdString : IEquatable<WorkerIdString>
+{
+    public WorkerIdString(string value)
+    {
+        Value = Guard.NotEmptyAndNotNull(value, nameof(value));
+    }
+
+    public string Value { get; }
+
+    public bool Equals(WorkerIdString? other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return Value == other.Value;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return ReferenceEquals(this, obj) || obj is WorkerIdString other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return Value.GetHashCode();
+    }
+
+    public override string ToString()
+    {
+        return Value;
+    }
+}

--- a/test/Camunda.Worker.Tests/CamundaWorkerBuilderTest.cs
+++ b/test/Camunda.Worker.Tests/CamundaWorkerBuilderTest.cs
@@ -16,7 +16,7 @@ public class CamundaWorkerBuilderTest
 
     public CamundaWorkerBuilderTest()
     {
-        _builder = new CamundaWorkerBuilder(_services, "testWorker");
+        _builder = new CamundaWorkerBuilder(_services, new WorkerIdString("testWorker"));
     }
 
     [Fact]

--- a/test/Camunda.Worker.Tests/Execution/LegacyFetchAndLockRequestProviderTests.cs
+++ b/test/Camunda.Worker.Tests/Execution/LegacyFetchAndLockRequestProviderTests.cs
@@ -13,8 +13,9 @@ public class LegacyFetchAndLockRequestProviderTests
     public void GetRequest_ShouldReturnsRequest()
     {
         // Arrange
+        var workerId = new WorkerIdString(new Faker().Lorem.Word());
         var fetchAndLockOptions = new Faker<FetchAndLockOptions>()
-            .RuleFor(o => o.WorkerId, f => f.Lorem.Word())
+            .RuleFor(o => o.WorkerId, workerId.Value)
             .RuleFor(o => o.MaxTasks, f => f.Random.Int(1, 10))
             .RuleFor(o => o.AsyncResponseTimeout, f => f.Random.Int(100, 10000))
             .RuleFor(o => o.UsePriority, f => f.Random.Bool())
@@ -28,6 +29,7 @@ public class LegacyFetchAndLockRequestProviderTests
         topicsProviderMock.Setup(p => p.GetTopics()).Returns(topics);
 
         var sut = new LegacyFetchAndLockRequestProvider(
+            workerId,
             topicsProviderMock.Object,
             Options.Create(fetchAndLockOptions)
         );

--- a/test/Camunda.Worker.Tests/Execution/LegacyFetchAndLockRequestProviderTests.cs
+++ b/test/Camunda.Worker.Tests/Execution/LegacyFetchAndLockRequestProviderTests.cs
@@ -15,7 +15,6 @@ public class LegacyFetchAndLockRequestProviderTests
         // Arrange
         var workerId = new WorkerIdString(new Faker().Lorem.Word());
         var fetchAndLockOptions = new Faker<FetchAndLockOptions>()
-            .RuleFor(o => o.WorkerId, workerId.Value)
             .RuleFor(o => o.MaxTasks, f => f.Random.Int(1, 10))
             .RuleFor(o => o.AsyncResponseTimeout, f => f.Random.Int(100, 10000))
             .RuleFor(o => o.UsePriority, f => f.Random.Bool())
@@ -39,7 +38,7 @@ public class LegacyFetchAndLockRequestProviderTests
 
         // Assert
         Assert.Same(topics, request.Topics);
-        Assert.Equal(fetchAndLockOptions.WorkerId, request.WorkerId);
+        Assert.Equal(workerId.Value, request.WorkerId);
         Assert.Equal(fetchAndLockOptions.MaxTasks, request.MaxTasks);
         Assert.Equal(fetchAndLockOptions.AsyncResponseTimeout, request.AsyncResponseTimeout);
         Assert.Equal(fetchAndLockOptions.UsePriority, request.UsePriority);

--- a/test/Camunda.Worker.Tests/Execution/StaticTopicsProviderTest.cs
+++ b/test/Camunda.Worker.Tests/Execution/StaticTopicsProviderTest.cs
@@ -9,32 +9,32 @@ public class StaticTopicsProviderTest
     [Fact]
     public void TestGetTopics()
     {
-        var descriptors = GetDescriptors();
+        var endpoints = GetEndpoints();
 
-        var topicsProvider = new StaticTopicsProvider(descriptors);
+        var topicsProvider = new StaticTopicsProvider(endpoints);
 
         var topics = topicsProvider.GetTopics().ToList();
 
         Assert.Equal(2, topics.Count);
 
-        Assert.Equal(descriptors[0].Metadata.TopicNames[0], topics[0].TopicName);
+        Assert.Equal(endpoints[0].Metadata.TopicNames[0], topics[0].TopicName);
         Assert.Null(topics[0].Variables);
 
-        Assert.Equal(descriptors[1].Metadata.TopicNames[0], topics[1].TopicName);
+        Assert.Equal(endpoints[1].Metadata.TopicNames[0], topics[1].TopicName);
         Assert.NotNull(topics[1].Variables);
         Assert.True(topics[1].LocalVariables);
-        Assert.Equal(descriptors[1].Metadata.LockDuration, topics[1].LockDuration);
+        Assert.Equal(endpoints[1].Metadata.LockDuration, topics[1].LockDuration);
     }
 
-    private static HandlerDescriptor[] GetDescriptors()
+    private static HandlerEndpoint[] GetEndpoints()
     {
         var workerId = new WorkerIdString("testWorker");
 
         Task FakeHandlerDelegate(IExternalTaskContext context) => Task.CompletedTask;
         return new[]
         {
-            new HandlerDescriptor(FakeHandlerDelegate, new HandlerMetadata(new[] {"topic1"}), workerId),
-            new HandlerDescriptor(FakeHandlerDelegate, new HandlerMetadata(new[] {"test2"}, 10_000)
+            new HandlerEndpoint(FakeHandlerDelegate, new HandlerMetadata(new[] {"topic1"}), workerId),
+            new HandlerEndpoint(FakeHandlerDelegate, new HandlerMetadata(new[] {"test2"}, 10_000)
             {
                 Variables = new[] {"X"},
                 LocalVariables = true

--- a/test/Camunda.Worker.Tests/Execution/StaticTopicsProviderTest.cs
+++ b/test/Camunda.Worker.Tests/Execution/StaticTopicsProviderTest.cs
@@ -28,15 +28,17 @@ public class StaticTopicsProviderTest
 
     private static HandlerDescriptor[] GetDescriptors()
     {
+        var workerId = new WorkerIdString("testWorker");
+
         Task FakeHandlerDelegate(IExternalTaskContext context) => Task.CompletedTask;
         return new[]
         {
-            new HandlerDescriptor(FakeHandlerDelegate, new HandlerMetadata(new[] {"topic1"})),
+            new HandlerDescriptor(FakeHandlerDelegate, new HandlerMetadata(new[] {"topic1"}), workerId),
             new HandlerDescriptor(FakeHandlerDelegate, new HandlerMetadata(new[] {"test2"}, 10_000)
             {
                 Variables = new[] {"X"},
                 LocalVariables = true
-            })
+            }, workerId)
         };
     }
 }

--- a/test/Camunda.Worker.Tests/Execution/TopicBasedEndpointProviderTest.cs
+++ b/test/Camunda.Worker.Tests/Execution/TopicBasedEndpointProviderTest.cs
@@ -16,7 +16,7 @@ public class TopicBasedEndpointProviderTest
         var workerId = new WorkerIdString("testWorker");
         var provider = new TopicBasedEndpointProvider(new[]
         {
-            new HandlerDescriptor(FakeHandlerDelegate, new HandlerMetadata(new[] {"topic1"}), workerId)
+            new HandlerEndpoint(FakeHandlerDelegate, new HandlerMetadata(new[] {"topic1"}), workerId)
         });
 
         var handlerDelegate = provider.GetEndpointDelegate(new ExternalTask("test", "test", "topic1"));
@@ -26,7 +26,7 @@ public class TopicBasedEndpointProviderTest
     [Fact]
     public void TestGetUnknownEndpointDelegate()
     {
-        var provider = new TopicBasedEndpointProvider(Enumerable.Empty<HandlerDescriptor>());
+        var provider = new TopicBasedEndpointProvider(Enumerable.Empty<HandlerEndpoint>());
         Assert.Throws<ArgumentException>(
             () => provider.GetEndpointDelegate(new ExternalTask("test", "test", "topic1"))
         );

--- a/test/Camunda.Worker.Tests/Execution/TopicBasedEndpointProviderTest.cs
+++ b/test/Camunda.Worker.Tests/Execution/TopicBasedEndpointProviderTest.cs
@@ -13,9 +13,10 @@ public class TopicBasedEndpointProviderTest
     {
         Task FakeHandlerDelegate(IExternalTaskContext context) => Task.CompletedTask;
 
+        var workerId = new WorkerIdString("testWorker");
         var provider = new TopicBasedEndpointProvider(new[]
         {
-            new HandlerDescriptor(FakeHandlerDelegate, new HandlerMetadata(new[] {"topic1"}))
+            new HandlerDescriptor(FakeHandlerDelegate, new HandlerMetadata(new[] {"topic1"}), workerId)
         });
 
         var handlerDelegate = provider.GetEndpointDelegate(new ExternalTask("test", "test", "topic1"));

--- a/test/Camunda.Worker.Tests/PipelineBuilderTest.cs
+++ b/test/Camunda.Worker.Tests/PipelineBuilderTest.cs
@@ -27,7 +27,7 @@ public class PipelineBuilderTest
     [InlineData(100)]
     public async Task TestBuildPipeline(int calls)
     {
-        IPipelineBuilder builder = new PipelineBuilder(new Faker().Random.String(), _serviceProvider);
+        IPipelineBuilder builder = new PipelineBuilder(_serviceProvider, new WorkerIdString(new Faker().Random.String()));
 
         Task LastDelegate(IExternalTaskContext context)
         {

--- a/test/Camunda.Worker.Tests/ServiceCollectionExtensionsTest.cs
+++ b/test/Camunda.Worker.Tests/ServiceCollectionExtensionsTest.cs
@@ -17,8 +17,6 @@ public class ServiceCollectionExtensionsTest
 
         using var provider = services.BuildServiceProvider();
 
-        var fetchAndLockOptions = provider.GetRequiredService<IOptions<FetchAndLockOptions>>().Value;
-        Assert.Equal("testWorker", fetchAndLockOptions.WorkerId);
         Assert.NotNull(provider.GetService<IOptions<WorkerEvents>>()?.Value);
 
         Assert.Contains(services, IsRegistered(typeof(IEndpointProvider), ServiceLifetime.Singleton));


### PR DESCRIPTION
**Breaking changes**

- `ICamundaWorkerBuilder.WorkerId` now returns `WorkerIdString` instead of `string`
- `WorkerId` property have been removed from `FetchAndLockOptions`
- `HandlerDescriptor` have been renamed to `HandlerEndpoint`