### PR TITLE
Use AddHostedService for registering WorkerHostedService

### DIFF
--- a/src/Camunda.Worker/ServiceCollectionExtensions.cs
+++ b/src/Camunda.Worker/ServiceCollectionExtensions.cs
@@ -32,7 +32,7 @@ public static class CamundaWorkerServiceCollectionExtensions
             provider.GetRequiredKeyedService<IExternalTaskProcessingService>(workerId.Value),
             provider.GetService<ILogger<DefaultCamundaWorker>>()
         ));
-        services.AddTransient<IHostedService>(provider => new WorkerHostedService(provider, workerId, numberOfWorkers));
+        services.AddHostedService(provider => new WorkerHostedService(provider, workerId, numberOfWorkers));
 
         return new CamundaWorkerBuilder(services, workerId)
             .AddDefaultFetchAndLockRequestProvider()


### PR DESCRIPTION
Transient registration causes the service to be disposed when the DI scope ends.

In most cases a transient scope should not be a problem, but in our case we have a multi-tenant structure where the hosted services are kicked off by a short-lived service scope.